### PR TITLE
Update solid-permissions to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "shorthash": "0.0.2",
     "solid-auth-tls": "0.0.4",
     "solid-namespace": "^0.1.0",
-    "solid-permissions": "^0.5.0",
+    "solid-permissions": "^0.5.1",
     "solid-web-client": "0.0.10"
   },
   "devDependencies": {


### PR DESCRIPTION
`solid-client` failed to install as a dependency for an app I'm working on due to the fact that it's `solid-permissions` dependency improperly builds itself during a postinstall hook. Having fixed the permissions lib, this should resolve the issue I was seeing.

@dmitrizagidulin please review