### PR TITLE
Add link to solid-auth-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM Version](https://img.shields.io/npm/v/solid-client.svg?style=flat)](https://npm.im/solid-client)
 [![Build Status](https://travis-ci.org/solid/solid-client.svg?branch=master)](https://travis-ci.org/solid/solid-client)
 
-## NOT SUPPORTED - PLEASE USE solid-auth-client
+## NOT SUPPORTED - PLEASE USE [solid-auth-client](https://github.com/solid/solid-auth-client)
 
 Javascript library for writing [Solid](https://github.com/solid/solid)
 applications. (See **[Changelog](CHANGELOG.md)** for version history.)


### PR DESCRIPTION
Since this repo is no longer supported and refers to `solid-auth-client` instead, it's convenient with a link at the top to click further.